### PR TITLE
Fix Diablo some more

### DIFF
--- a/packages/sx05re/emuelec-ports/sources/ports.yaml
+++ b/packages/sx05re/emuelec-ports/sources/ports.yaml
@@ -61,7 +61,8 @@ Diablo:
     - ln -sf /storage/roms/ports/diablo/diabdat.mpq /storage/.local/share/diasurgical/devilution/diabdat.mpq
     - fi
     - cd /storage/roms/ports
-    - ${PORT} >> $EE_LOG 2>&1
+    - LOG_FILE=/storage/roms/ports/diablo/log.txt
+    - ${PORT} >> $LOG_FILE 2>&1
 
 Dinothawr:
   description: Dinothawr is a block pushing puzzle game on slippery surfaces. Our hero is a dinosaur whose friends are trapped in ice. Through puzzles it is your task to free the dinos from their ice prison.

--- a/packages/sx05re/emuelec/config/emuelec/scripts/batocera/batocera-systems
+++ b/packages/sx05re/emuelec/config/emuelec/scripts/batocera/batocera-systems
@@ -462,7 +462,10 @@ systems = {
 										   { "md5": "32736f17079d0b2b7024407c39bd3050", "file": "bios/scph5502.bin"   } ] },
 
 	# Ports
-	"Diablo": { "name": "Diablo 1 (devilutionx) ", "biosFiles": [ { "md5": "68f049866b44688a7af65ba766bef75a", "file": "ports/diablo/diabdat.mpq" } ] },
+	"Diablo": { "name": "Diablo 1 (devilutionx) ", "biosFiles": [
+		{ "md5": "68f049866b44688a7af65ba766bef75a", "file": "ports/diablo/diabdat.mpq" }, # Original retail release
+		{ "md5": "011bc6518e6166206231080a4440b373", "file": "ports/diablo/diabdat.mpq" }, # GOG release
+	] },
 	
 	"Dinothawr": { "name": "Dinothawr", "biosFiles": [ { "md5": "", "file": "ports/dinothawr/level_3-3.tmx" },
                                                        { "md5": "", "file": "ports/dinothawr/level_7-2.tmx" },


### PR DESCRIPTION
This fixes `$EE_LOG: ambiguous redirect` error when starting Diablo. It now launches when run from the menu.

It still shows the red Software Failure screen on exit but exit code is zero. No idea where that is coming from.

An alternative solution might be to define `EE_LOG` as seen here: https://github.com/EmuELEC/EmuELEC/blob/95ac42d74700311c01413ccb17f65857b052dc40/packages/sx05re/emuelec/profile.d/99-emuelec.conf#L15

But it seemed weird Diablo being the only program to write to emuelec.log.

&nbsp;
Also added the diabdat.mpq hash for the GOG release. Not sure if the bios check actually supports alternatives. At least this documents another file version devilutionx works with. The wrong hash on my file was confusing me a bit initially.