### PR TITLE
MPV (mplayer) solution with gamepad play controls

### DIFF
--- a/packages/351elec/config/emuelec/configs/jslisten_mpv.cfg
+++ b/packages/351elec/config/emuelec/configs/jslisten_mpv.cfg
@@ -1,0 +1,45 @@
+[Generic]
+program="/usr/bin/killall retroarch"
+button1=8
+button2=7
+button3=6
+ee_evdev="auto"
+
+# ******** Do not edit anything above this line, in fact not even this comment! ********
+
+[Pause]
+program="/emuelec/scripts/vid_pause.sh"
+button1=0
+ee_evdev="auto"
+
+[Skip5s]
+program="/emuelec/scripts/vid_skip5.sh"
+button1=5
+ee_evdev="auto"
+
+[Back5s]
+program="/emuelec/scripts/vid_skipback5.sh"
+button1=4
+ee_evdev="auto"
+
+[Skip60s]
+program="/emuelec/scripts/vid_skip60.sh"
+button1=11
+ee_evdev="auto"
+
+[Back60s]
+program="/emuelec/scripts/vid_skipback60.sh"
+button1=10
+ee_evdev="auto"
+
+[BrightnessUp]
+program="/emuelec/scripts/brightness up"
+button1=8
+button2=5
+ee_evdev="auto"
+
+[BrightnessDown]
+program="/emuelec/scripts/brightness down"
+button1=8
+button2=4
+ee_evdev="auto"

--- a/packages/351elec/config/emuelec/configs/jslisten_std.cfg
+++ b/packages/351elec/config/emuelec/configs/jslisten_std.cfg
@@ -1,0 +1,20 @@
+[Generic]
+program="/usr/bin/killall retroarch"
+button1=8
+button2=7
+button3=6
+ee_evdev="auto"
+
+# ******** Do not edit anything above this line, in fact not even this comment! ********
+
+[BrightnessUp]
+program="/emuelec/scripts/brightness up"
+button1=8
+button2=5
+ee_evdev="auto"
+
+[BrightnessDown]
+program="/emuelec/scripts/brightness down"
+button1=8
+button2=4
+ee_evdev="auto"

--- a/packages/351elec/config/emuelec/scripts/emuelecRunEmu.sh
+++ b/packages/351elec/config/emuelec/scripts/emuelecRunEmu.sh
@@ -22,6 +22,8 @@ LOGSDIR="/tmp/logs"
 LOGFILE="emuelec.log"
 TBASH="/usr/bin/bash"
 JSLISTENCONF="/emuelec/configs/jslisten.cfg"
+JSLISTENSTDCONF="/emuelec/configs/jslisten_std.cfg"
+JSLISTENMPVCONF="/emuelec/configs/jslisten_mpv.cfg"
 RATMPCONF="/tmp/retroarch/ee_retroarch.cfg"
 RATMPCONF="/storage/.config/retroarch/retroarch.cfg"
 NETPLAY="No"
@@ -195,6 +197,12 @@ function jslisten() {
 	if [ "$1" == "set" ]
 	then
 		systemctl stop jslisten
+		if [ "$2" == "mpv" ]
+		then
+			cp ${JSLISTENMPVCONF} ${JSLISTENCONF}
+		else
+			cp ${JSLISTENSTDCONF} ${JSLISTENCONF}
+		fi
 		sed -i "2s|program=.*|program=\"/usr/bin/killall ${2}\"|" ${JSLISTENCONF}
 		systemctl start jslisten
 	elif [ "$1" == "stop" ]
@@ -331,8 +339,8 @@ if [ -z ${LIBRETRO} ]; then
 			fi
 		;;
 		"mplayer")
-			jslisten set "${EMU}"
-			RUNTHIS='${TBASH} mplayer_video "${ROMNAME}" "${EMU}"'
+			jslisten set "mpv"
+			RUNTHIS='${TBASH} /usr/bin/mpv_video.sh "${ROMNAME}"'
 		;;
 		"shell")
 			jslisten set "bash"

--- a/packages/351elec/config/emuelec/scripts/mpv_video.sh
+++ b/packages/351elec/config/emuelec/scripts/mpv_video.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+/usr/bin/mpv --input-ipc-server=/tmp/mpvsocket ${1}

--- a/packages/351elec/config/emuelec/scripts/vid_pause.sh
+++ b/packages/351elec/config/emuelec/scripts/vid_pause.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo '{"command":["keypress", "p"]}' | socat - /tmp/mpvsocket

--- a/packages/351elec/config/emuelec/scripts/vid_skip5.sh
+++ b/packages/351elec/config/emuelec/scripts/vid_skip5.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo '{"command":["keypress", "RIGHT"]}' | socat - /tmp/mpvsocket

--- a/packages/351elec/config/emuelec/scripts/vid_skip60.sh
+++ b/packages/351elec/config/emuelec/scripts/vid_skip60.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo '{"command":["keypress", "UP"]}' | socat - /tmp/mpvsocket

--- a/packages/351elec/config/emuelec/scripts/vid_skipback5.sh
+++ b/packages/351elec/config/emuelec/scripts/vid_skipback5.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo '{"command":["keypress", "LEFT"]}' | socat - /tmp/mpvsocket

--- a/packages/351elec/config/emuelec/scripts/vid_skipback60.sh
+++ b/packages/351elec/config/emuelec/scripts/vid_skipback60.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo '{"command":["keypress", "DOWN"]}' | socat - /tmp/mpvsocket

--- a/packages/ui/emuelec-emulationstation/config/es_systems.cfg
+++ b/packages/ui/emuelec-emulationstation/config/es_systems.cfg
@@ -672,12 +672,7 @@ All systems must be contained within the <systemList> tag.-->
     <emulators>
       <emulator name="mpv">
         <cores>
-          <core>mpv</core>
-        </cores>
-      </emulator>
-      <emulator name="ffplay">
-        <cores>
-          <core>ffplay</core>
+          <core default="true">mpv</core>
         </cores>
       </emulator>
     </emulators>

--- a/packages/ui/emuelec-emulationstation/config/scripts/configscripts/z_getkillkeys.sh
+++ b/packages/ui/emuelec-emulationstation/config/scripts/configscripts/z_getkillkeys.sh
@@ -3,7 +3,8 @@
 # IMPORTANT: js0 is always used as default, but you can change this in ee_kill.cfg
 
 FOUND=0
-EE_CFG="/emuelec/configs/jslisten.cfg"
+EE_CFG_STD="/emuelec/configs/jslisten_std.cfg"
+EE_CFG_MPV="/emuelec/configs/jslisten_mpv.cfg"
 EE_DEV="$(cat $EE_CFG | grep ee_evdev | awk -F= '{print $2}' | tr -d \")"
 
 [[ $EE_DEV =~ auto ]] && EE_DEV=$(basename /dev/input/js0)
@@ -24,9 +25,12 @@ if [ $FOUND = 1 ]; then
         KEY1=$(cat "$EE_GAMEPAD" | grep -E 'input_l2_btn' | cut -d '"' -f2)
         KEY2=$(cat "$EE_GAMEPAD" | grep -E 'hotkey_btn' | cut -d '"' -f2)
         KEY3=$(cat "$EE_GAMEPAD" | grep -E 'input_exit_emulator_btn' | cut -d '"' -f2)
-        sed -i "3s|button1=.*|button1=${KEY1}|" ${EE_CFG}
-        sed -i "4s|button2=.*|button2=${KEY2}|" ${EE_CFG}
-        sed -i "5s|button3=.*|button3=${KEY3}|" ${EE_CFG}
+        sed -i "3s|button1=.*|button1=${KEY1}|" ${EE_CFG_STD}
+        sed -i "4s|button2=.*|button2=${KEY2}|" ${EE_CFG_STD}
+        sed -i "5s|button3=.*|button3=${KEY3}|" ${EE_CFG_STD}
+        sed -i "3s|button1=.*|button1=${KEY1}|" ${EE_CFG_MPV}
+        sed -i "4s|button2=.*|button2=${KEY2}|" ${EE_CFG_MPV}
+        sed -i "5s|button3=.*|button3=${KEY3}|" ${EE_CFG_MPV}
 
         DEVICE=$(cat "$EE_GAMEPAD" | grep -E 'input_device' | cut -d '"' -f2)
         echo "Kill combo set to ${KEY1}+${KEY2}+${KEY3} from $EE_GAMEPAD Dev: $EE_DEV"


### PR DESCRIPTION
This isn't as efficient as I'd like.  I changed what I had done on my own to reflect your changes to the jslisten code (and specifically the changes in both emuelecRunEmu.sh and the new script for setting the kill keys and keeping that synced), however my solution here complicates that by keeping TWO different jslisten.cfg configs.  One is the standard version which has just the brightness controls beyond the kill keys, and the second being the mpv version which has the play/pause and skip forward/back 5s & 60s controls.  We definitely wouldn't want those out there all the time - hence why this is a little messy.
