### PR TITLE
Add a way to have a custom mount of /storage/roms

### DIFF
--- a/packages/351elec/sources/autostart.sh
+++ b/packages/351elec/sources/autostart.sh
@@ -6,7 +6,7 @@
 # Source predefined functions and variables
 . /etc/profile
 
-# run custom_start before_start FE scripts
+# run custom_start before_start before mount so that it can override the default mount behavior
 /storage/.config/custom_start.sh before_start
 
 if [ ! -d "/storage/roms" ]

--- a/packages/351elec/sources/autostart.sh
+++ b/packages/351elec/sources/autostart.sh
@@ -6,6 +6,9 @@
 # Source predefined functions and variables
 . /etc/profile
 
+# run custom_start before_start FE scripts
+/storage/.config/custom_start.sh before_start
+
 if [ ! -d "/storage/roms" ]
 then
   mkdir /storage/roms


### PR DESCRIPTION
With this small patch it is possible to override the default mount behavior. It makes possible to add a new case to `custom_start.sh` (`before_start`) and do the desired override. The reason of this override is that I find FAT32 unreliable, especially with big partitions (mine is ~500 GiB). Several times I had problems with errors and lost files. That happened because of crashed, hanged or forcibly rebooted system, also it can happen with an unexpected battery drawdown.  So, to avoid such situations I prefer not to use FAT32, but the existing hook (`/storage/.config/custom_start.sh before`) is called to late that complicates the idea. So, with this approach the things can become less complicated.