### PR TITLE
tyrquake and prboom 351p resolution patches

### DIFF
--- a/packages/games/libretro/prboom/patches/01_351p_resolution.patch
+++ b/packages/games/libretro/prboom/patches/01_351p_resolution.patch
@@ -1,0 +1,34 @@
+diff --git a/libretro/libretro.c b/libretro/libretro.c
+index f68d93f..63efdcf 100644
+--- a/libretro/libretro.c
++++ b/libretro/libretro.c
+@@ -385,7 +385,7 @@ void retro_get_system_av_info(struct retro_system_av_info *info)
+   info->geometry.base_height = SCREENHEIGHT;
+   info->geometry.max_width = SCREENWIDTH;
+   info->geometry.max_height = SCREENHEIGHT;
+-  info->geometry.aspect_ratio = 4.0 / 3.0;
++  info->geometry.aspect_ratio = 3.0 / 2.0;
+ }
+
+
+diff --git a/libretro/libretro_core_options.h b/libretro/libretro_core_options.h
+index e764703..dc65f4a 100644
+--- a/libretro/libretro_core_options.h
++++ b/libretro/libretro_core_options.h
+@@ -33,6 +33,7 @@ struct retro_core_option_definition option_defs_us[] = {
+       "Configure the resolution. Requires a restart.",
+       {
+          { "320x200",   NULL },
++         { "480x320",   NULL },
+          { "640x400",   NULL },
+          { "960x600",   NULL },
+          { "1280x800",  NULL },
+@@ -42,7 +43,7 @@ struct retro_core_option_definition option_defs_us[] = {
+          { "2560x1600", NULL },
+          { NULL, NULL },
+       },
+-      "320x200"
++      "480x320"
+    },
+    {
+       "prboom-mouse_on",

--- a/packages/games/libretro/tyrquake/patches/01_351p_resolution.patch
+++ b/packages/games/libretro/tyrquake/patches/01_351p_resolution.patch
@@ -1,5 +1,18 @@
+diff --git a/common/libretro.c b/common/libretro.c
+index 4f48b90..8d28885 100644
+--- a/common/libretro.c
++++ b/common/libretro.c
+@@ -572,7 +572,7 @@ void retro_get_system_av_info(struct retro_system_av_info *info)
+    info->geometry.base_height  = height;
+    info->geometry.max_width    = width;
+    info->geometry.max_height   = height;
+-   info->geometry.aspect_ratio = 4.0 / 3.0;
++   info->geometry.aspect_ratio = 3.0 / 2.0;
+ }
+
+ void retro_set_environment(retro_environment_t cb)
 diff --git a/common/libretro_core_options.h b/common/libretro_core_options.h
-index e15b3a3..2d0f7ef 100644
+index e15b3a3..8eff659 100644
 --- a/common/libretro_core_options.h
 +++ b/common/libretro_core_options.h
 @@ -42,6 +42,7 @@ struct retro_core_option_definition option_defs_us[] = {
@@ -10,3 +23,21 @@ index e15b3a3..2d0f7ef 100644
           { "512x224",   NULL },
           { "512x240",   NULL },
           { "512x384",   NULL },
+@@ -71,7 +72,7 @@ struct retro_core_option_definition option_defs_us[] = {
+ #elif defined(DINGUX)
+       "320x240"
+ #else
+-      "320x200"
++      "480x320"
+ #endif
+    },
+    {
+@@ -145,7 +146,7 @@ struct retro_core_option_definition option_defs_us[] = {
+          { "enabled",   "Enabled" },
+          { NULL, NULL },
+       },
+-      "disabled"
++      "enabled"
+    },
+    {
+       "tyrquake_analog_deadzone",


### PR DESCRIPTION
Update tyrquake default resolution and add prboom resolution patch to default both games to 480x320 and the correct aspect ratio for the cores